### PR TITLE
Use python distroless instead of google distroless for final stage

### DIFF
--- a/build/Dockerfile.distroless
+++ b/build/Dockerfile.distroless
@@ -1,11 +1,3 @@
-# This is our strategy for getting a clean (from CVE perspective) base image for python-based services.
-# This mostly takes from https://github.com/alexdmoss/distroless-python
-# We need to build our own to be able to get new debian versions with fixes.
-
-# Google periodically updates distroless images but just uses latest
-# CVEs will typically get fixed in versions (e.g deb12u7) and we'll need to rebuild this to incorporate them.
-ARG GOOGLE_DISTROLESS_BASE_IMAGE=gcr.io/distroless/cc-debian12:latest
-
 # ARG instructions do not create additional layers. Instead, next layers will
 # concatenate them. Also, we have to repeat ARG instructions in each build
 # stage that uses them.
@@ -184,7 +176,7 @@ COPY build/fonts.conf /etc/fonts/conf.d/100-gotenberg.conf
 # ----------------------------------------------
 # Final stage
 # ----------------------------------------------
-FROM ${GOOGLE_DISTROLESS_BASE_IMAGE} AS base
+FROM public.ecr.aws/j9h1x6x3/distroless-python:latest AS base
 
 # Set platform-specific CHIPSET_ARCH
 FROM base AS base-amd64
@@ -197,11 +189,6 @@ ARG CHIPSET_ARCH=aarch64-linux-gnu
 
 ARG TARGETARCH
 FROM base-${TARGETARCH}
-
-# Required for unoconverter
-COPY --from=gotenberg-binary-stage /usr/bin/python /usr/bin/python
-COPY --from=gotenberg-binary-stage /usr/lib/python3 /usr/lib/python3
-COPY --from=gotenberg-binary-stage /usr/lib/python3.11 /usr/lib/python3.11
 
 ENV PYTHONPATH="/usr/local/lib/python3.11/dist-packages:"
 


### PR DESCRIPTION
2F scanning complains about the copied in python here. This is untested, will rebuild the image in conduit CI and test that.